### PR TITLE
Fix slow verify stage.

### DIFF
--- a/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
@@ -32,7 +32,9 @@ public final class FFMPEG {
 
 // ffprobe
 
-    public final int getFrames(final File input){
+    private final Pattern frames = Pattern.compile("^\\Qframe=\\E *(\\d+)\\Q fps=\\E.+$", Pattern.MULTILINE);
+
+    private int getFrames(final File input){
         if(input == null) return -1;
         
         final String[] args = new String[]{
@@ -44,8 +46,12 @@ public final class FFMPEG {
 
         try{
             final String output = executor.executeFFMPEG(args);
-            // todo: parse this to get frames
-            return 0;
+            final Matcher matcher = frames.matcher(output);
+
+            if(!matcher.find())
+                return -1;
+
+            return Integer.parseInt(matcher.group(1));
         }catch(final IOException ignored){
             return -1;
         }

--- a/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
@@ -32,26 +32,26 @@ public final class FFMPEG {
 
 // ffprobe
 
-    private final Pattern duration = Pattern.compile("\\Q[FORMAT]\\E\\r?\\n\\Qduration=\\E(\\d+\\.\\d+)\\r?\\n\\Q[/FORMAT]\\E",Pattern.MULTILINE);
-    // duration in seconds
-    public final float getDuration(final File input) throws IOException{
-        if(!input.exists()) throw new FileNotFoundException(input.getAbsolutePath());
-
+    public final int getFrames(final File input){
+        if(input == null) return -1;
+        
         final String[] args = new String[]{
             "-i", '"' + input.getAbsolutePath() + '"',
-            "-v", "0",
-            "-show_entries", "format=duration" // get format tag duration
+            "-map", "0:v:0", // copy video track
+            "-c", "copy", // copy codec
+            "-f", "null -" // destroy output
         };
 
-        final String result   = executor.executeFFPROBE(args);
-        final Matcher matcher = duration.matcher(result);
-
-        return result.isBlank() || matcher.matches()
-               ? (float) (Math.ceil(Float.parseFloat(matcher.group(1)) * 100) / 100)
-               : -1f;
+        try{
+            final String output = executor.executeFFMPEG(args);
+            // todo: parse this to get frames
+            return 0;
+        }catch(final IOException ignored){
+            return -1;
+        }
     }
 
-    private final Pattern frames = Pattern.compile("\\Qstream|\\E(\\d+)/(\\d+)\\|(\\d+\\.\\d+)\\|(\\d*)",Pattern.MULTILINE);
+    private final Pattern framerate = Pattern.compile("\\Q[STREAM]\\E\\r?\\n\\Qr_frame_rate=\\E(\\d+)/(\\d+)\\r?\\n\\Qduration=\\E(\\d+\\.\\d+)\\r?\\n\\Q[/STREAM]\\E", Pattern.MULTILINE);
     public final boolean verifyFileIntegrity(final File input){
         if(!input.exists()) return false;
 
@@ -59,24 +59,22 @@ public final class FFMPEG {
             "-i", '"' + input.getAbsolutePath() + '"',
             "-v", "0",
             "-select_streams", "v", // video stream only
-            "-show_entries", "stream=r_frame_rate,nb_read_frames,duration", // get framerate, total frames, and duration
-            "-count_frames", // count frames
-            "-of","compact=p=1:nk=1", // other stuff
+            "-show_entries", "stream=r_frame_rate,duration", // get framerate, and duration
         };
 
         try{
             final String result   = executor.executeFFPROBE(args);
-            final Matcher matcher = frames.matcher(result);
+            final Matcher matcher = framerate.matcher(result);
 
             if(!matcher.matches())
                 return false;
 
             final int framerate     = Integer.parseInt(matcher.group(1)) / Integer.parseInt(matcher.group(2));
             final float duration    = Float.parseFloat(matcher.group(3));
-            final int frames        = Integer.parseInt(matcher.group(4));
+            final int frames        = getFrames(input);
 
             // framerate * duration (calculated frame rate)
-            return framerate * duration == frames;
+            return frames != -1 && Math.abs((framerate * duration) - frames) < 0.0001; // <- approximate to nearest ten thousanth
         }catch(final IOException | NumberFormatException ignored){
             return false;
         }
@@ -229,8 +227,8 @@ public final class FFMPEG {
     public String toString(){
         return new ToStringBuilder(getClass().getSimpleName())
             .addObject("executor",executor)
-            .addObject("duration_regexp",duration.pattern())
-            .addObject("frames_regexp",frames.pattern())
+            //.addObject("duration_regexp",duration.pattern()) // fixme
+            .addObject("frames_regexp", framerate.pattern())
             .addObject("metadata_regexp",metadata.pattern())
             .toString();
     }

--- a/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
+++ b/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
@@ -44,11 +44,6 @@ public class ffmpegTests {
     @TempDir
     public final File dir = new File(String.valueOf(UUID.randomUUID()));
 
-    @Test @Disabled
-    public void testFrames(){
-        // todo
-    }
-
     @Test
     public void testVerify(){
         Assertions.assertTrue(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/video.mp4")));

--- a/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
+++ b/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
@@ -44,9 +44,9 @@ public class ffmpegTests {
     @TempDir
     public final File dir = new File(String.valueOf(UUID.randomUUID()));
 
-    @Test
-    public void testDuration() throws IOException{
-        Assertions.assertEquals(4.97f, ffmpeg.getDuration(new File("src/test/resources/format/video.mp4")), 0);
+    @Test @Disabled
+    public void testFrames(){
+        // todo
     }
 
     @Test


### PR DESCRIPTION
Fixes #16 

- Removes `getDuration` (unused)
- Removes `-count_frames` from probe (too slow)
- Adds `getFrames` and fixes verify