### PR TITLE
Add file verification flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ rexedia -i "file.mp4" -c "(.+)" "$1.png" -b -v 3
 |<kbd>-﻿b</kbd> <kbd>-﻿backup</kbd>|*`[boolean]`*|If true, input files will be backed up.|
 |<kbd>-﻿l</kbd> <kbd>-﻿logging</kbd>|*`[boolean]`*|If true, log files will be generated.|
 |<kbd>-﻿d</kbd> <kbd>-﻿debug</kbd>|*`[boolean]`*|If true, debug logs will be generated.|
-|<kbd>-﻿v</kbd> <kbd>-verify</kbd>|*`[int]`*|File validation level. 0 = off (default), 1 = frames within range, 2 = frames equal to or exceeding, 3 = exact frame count.|
-|<kbd>-﻿vd</kbd> <kbd>-﻿verifyDiscrepancy</kbd>|*`[int]`*|Frame difference range (only for verify 1).|
+|<kbd>-﻿v</kbd> <kbd>-verify</kbd>|*`[int]`*|File validation level. 0 = off, 1 = frames within range (default), 2 = frames equal to or exceeding within range, 3 = exact frame count.|
+|<kbd>-﻿vd</kbd> <kbd>-﻿verifyDiscrepancy</kbd>|*`[int]`*|Frame difference range (only for verify 1 or 2).|
 |<kbd>-﻿pc</kbd> <kbd>-﻿preserveCover</kbd>|*`[boolean]`*|If true, files with existing cover art will not get erased unless a new one is specified.|
 |<kbd>-﻿pm</kbd> <kbd>-﻿preserveMeta</kbd>|*`[boolean]`*|If true, files will preserve any existing metadata in the final output.|
 |<kbd>-﻿p</kbd> <kbd>-﻿preset</kbd>|*`[file]`*|The [presets](#presets) file path. Overrides cover, metadata, and output flags. Can only be used once.|

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ rexedia -i "file.mp4" -c "(.+)" "$1.png" -b
 |<kbd>-﻿b</kbd> <kbd>-﻿backup</kbd>|*`[boolean]`*|If true, input files will be backed up.|
 |<kbd>-﻿l</kbd> <kbd>-﻿logging</kbd>|*`[boolean]`*|If true, log files will be generated.|
 |<kbd>-﻿d</kbd> <kbd>-﻿debug</kbd>|*`[boolean]`*|If true, debug logs will be generated.|
+|<kbd>-﻿v</kbd> <kbd>-verify</kbd>|*`[int]`*|File validation level. 0 = off (default), 1 = frames within range, 2 = frames equal to or exceeding, 3 = exact frame count.|
+|<kbd>-﻿vd</kbd> <kbd>-﻿verifyDiscrepancy</kbd>|*`[int]`*|Frame difference range (only for verify 1).|
 |<kbd>-﻿pc</kbd> <kbd>-﻿preserveCover</kbd>|*`[boolean]`*|If true, files with existing cover art will not get erased unless a new one is specified.|
 |<kbd>-﻿pm</kbd> <kbd>-﻿preserveMeta</kbd>|*`[boolean]`*|If true, files will preserve any existing metadata in the final output.|
 |<kbd>-﻿p</kbd> <kbd>-﻿preset</kbd>|*`[file]`*|The [presets](#presets) file path. Overrides cover, metadata, and output flags. Can only be used once.|

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ metadata:
 ## ✔ Safe Video Formatting
 
 Rexedia preserves the integrity of the video file.
-- Media file integrity is verified at every stage.
+- Verify file integrity using the `-v` flag.
 - Backup files will always be saved on format failure.
 - Use the `-b` flag to keep backup files even on successful formats.
 
 ```shell
-rexedia -i "file.mp4" -c "(.+)" "$1.png" -b
+rexedia -i "file.mp4" -c "(.+)" "$1.png" -b -v 3
 ```
 
 # Arguments

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-Version=1.1.0
+Version=1.2.0
 Name="rexedia"
 Vendor="Ktt Development"
 Workspace=package

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ jpackage \
 --main-class com.kttdevelopment.rexedia.Main \
 --app-version $Version \
 --vendor "$Vendor" \
---copyright "$Vendor 2020" \
+--copyright "$Vendor 2021" \
 --win-console
 
 # installer
@@ -37,5 +37,5 @@ jpackage \
 --main-class com.kttdevelopment.rexedia.Main \
 --app-version $Version \
 --vendor "$Vendor" \
---copyright "$Vendor 2020" \
+--copyright "$Vendor 2021" \
 --win-console

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kttdevelopment</groupId>
     <artifactId>rexedia</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/Ktt-Development/rexedia</url>

--- a/src/main/java/com/kttdevelopment/rexedia/Main.java
+++ b/src/main/java/com/kttdevelopment/rexedia/Main.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia;
 
 import com.kttdevelopment.rexedia.utility.ExceptionUtility;

--- a/src/main/java/com/kttdevelopment/rexedia/Main.java
+++ b/src/main/java/com/kttdevelopment/rexedia/Main.java
@@ -70,11 +70,20 @@ public abstract class Main {
                         setFormatter(new LoggerFormatter(true,false));
                     }});
 
-                if(debug)
+                if(debug){
+                    Logger.getGlobal().config(
+                        "OS: "              + System.getProperty("os.name").toLowerCase() + '\n' +
+                        "Java Version: "    + System.getProperty("java.version") + '\n' +
+                        "Args: "            + Arrays.toString(args) + '\n' +
+                        "Config: "          + config + '\n' +
+                        "Preset: "          + preset + '\n' +
+                        "FFMPEG: "          + ffmpeg + '\n'
+                    );
                     logger.addHandler(new FileHandler("debug.log"){{
                         setLevel(Level.ALL);
                         setFormatter(new LoggerFormatter(true,true));
                     }});
+                }
             }
 
             // format

--- a/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
+++ b/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
@@ -85,10 +85,10 @@ public final class Configuration {
             .build(),
         new Option.Builder<>(VERIFY)
             .setLongFlag("verify")
-            .setDesc("Set file validation level, 0 = none, 1 = similar, 2 = exact or greater, 3 = exact")
+            .setDesc("Set file validation level, 0 = none, 1 = frames within range (default), 2 = exact frames or exceeding within range, 3 = exact frame count")
             .setExpectedArgs(1)
             .argsRequired()
-            .setDefaultValue(0)
+            .setDefaultValue(1)
             .build(),
         new Option.Builder<>(VERDIFF)
             .setLongFlag("verifyDiscrepancy")

--- a/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
+++ b/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
@@ -18,6 +18,8 @@ public final class Configuration {
         BACKUP  = "b",
         DEBUG   = "d",
         LOGGING = "l",
+        VERIFY  = "v",
+        VERDIFF = "vd",
         PRECOV  = "pc",
         PREMETA = "pm",
         PRESET  = "p",
@@ -49,6 +51,13 @@ public final class Configuration {
             .argsOptional()
             .setDefaultValue(false)
             .build(),
+        new Option.Builder<>(DEBUG)
+            .setLongFlag("debug")
+            .setDesc("Run logging in debug mode and create a debug file")
+            .setExpectedArgs(1)
+            .argsOptional()
+            .setDefaultValue(false)
+            .build(),
         new Option.Builder<>(LOGGING)
             .setLongFlag("log")
             .setDesc("Log process to a file")
@@ -56,12 +65,19 @@ public final class Configuration {
             .argsOptional()
             .setDefaultValue(false)
             .build(),
-        new Option.Builder<>(DEBUG)
-            .setLongFlag("debug")
-            .setDesc("Run logging in debug mode and create a debug file")
+        new Option.Builder<>(VERIFY)
+            .setLongFlag("verify")
+            .setDesc("Set file validation level, 0 = none, 1 = similar, 2 = exact or greater, 3 = exact")
             .setExpectedArgs(1)
-            .argsOptional()
-            .setDefaultValue(false)
+            .argsRequired()
+            .setDefaultValue(0)
+            .build(),
+        new Option.Builder<>(VERDIFF)
+            .setLongFlag("verifyDiscrepancy")
+            .setDesc("Set the maximum frame difference discrepancy")
+            .setExpectedArgs(1)
+            .argsRequired()
+            .setDefaultValue(100)
             .build(),
         new Option.Builder<>(PRECOV)
             .setLongFlag("preserveCover")
@@ -106,6 +122,7 @@ public final class Configuration {
     private final Preset preset;
     private final Map<String,Object> configuration = new HashMap<>();
 
+    @SuppressWarnings("SpellCheckingInspection")
     public Configuration(final String... args) throws ParseException, IOException{
         final Options options = new Options();
         for(final Option<?> option : defaultOptions){
@@ -156,6 +173,14 @@ public final class Configuration {
             preset = p.build();
         }else{
             throw new MissingOptionException(META);
+        }
+        if(cmd.hasOption(VERIFY)){
+            int v = Integer.parseInt(cmd.getOptionValue(VERIFY));
+            if(v < 0 || v > 3)
+                throw new IllegalArgumentException("Verify mode can only be 0-3");
+            if(cmd.hasOption(VERDIFF))
+                if(Integer.parseInt(cmd.getOptionValue(VERDIFF)) < 0)
+                    throw new IllegalArgumentException("Verify discrepancy must be a positive integer");
         }
         if(cmd.hasOption(WALK))
             configuration.put(WALK, cmd.getOptionValue(WALK) == null || Boolean.parseBoolean(cmd.getOptionValue(WALK)));

--- a/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
+++ b/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.config;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
+++ b/src/main/java/com/kttdevelopment/rexedia/config/Configuration.java
@@ -166,7 +166,9 @@ public final class Configuration {
             throw new MissingOptionException(INPUT);
         }
         if(cmd.hasOption(PRESET)){
-            preset = new PresetParser().parse(new File(cmd.getOptionValue(PRESET)));
+            String path = cmd.getOptionValue(PRESET);
+            preset = new PresetParser().parse(new File(path));
+            configuration.put(PRESET, path);
         }else if(cmd.hasOption(COVER) || cmd.hasOption(META) || cmd.hasOption(OUTPUT)){
             final Preset.Builder p = new Preset.Builder();
             if(cmd.hasOption(COVER)){
@@ -193,12 +195,15 @@ public final class Configuration {
             throw new MissingOptionException(META);
         }
         if(cmd.hasOption(VERIFY)){
+            configuration.put(VERIFY, Integer.parseInt(cmd.getOptionValue(VERIFY)));
             int v = Integer.parseInt(cmd.getOptionValue(VERIFY));
             if(v < 0 || v > 3)
                 throw new IllegalArgumentException("Verify mode can only be 0-3");
-            if(cmd.hasOption(VERDIFF))
+            if(cmd.hasOption(VERDIFF)){
+                configuration.put(VERDIFF, cmd.getOptionValue(VERDIFF));
                 if(Integer.parseInt(cmd.getOptionValue(VERDIFF)) < 0)
                     throw new IllegalArgumentException("Verify discrepancy must be a positive integer");
+            }
         }
         if(cmd.hasOption(WALK))
             configuration.put(WALK, cmd.getOptionValue(WALK) == null || Boolean.parseBoolean(cmd.getOptionValue(WALK)));
@@ -227,7 +232,6 @@ public final class Configuration {
     @Override
     public String toString(){
         return new ToStringBuilder(getClass().getSimpleName())
-            .addObject("defaultOptions", defaultOptions)
             .addObject("preset",preset)
             .addObject("configuration", configuration)
             .toString();

--- a/src/main/java/com/kttdevelopment/rexedia/config/Option.java
+++ b/src/main/java/com/kttdevelopment/rexedia/config/Option.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.config;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/format/CommandExecutor.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/CommandExecutor.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.format;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.format;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/FFMPEG.java
@@ -108,8 +108,8 @@ public final class FFMPEG {
                         return false;
                     case 1: // if file frames within range
                         return Math.abs(diff) <= verifyDiscrepancy;
-                    case 2: // if file frames exceed calculated
-                        return diff >= 0;
+                    case 2: // if file frames exceed calculated within range
+                        return diff >= 0 && diff <= verifyDiscrepancy;
                     case 3: // if frames exact
                         return diff == 0;
                 }

--- a/src/main/java/com/kttdevelopment/rexedia/format/FFMPEGExecutor.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/FFMPEGExecutor.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.format;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/format/MetadataFormatter.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/MetadataFormatter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.format;
 
 import com.kttdevelopment.rexedia.config.Configuration;

--- a/src/main/java/com/kttdevelopment/rexedia/format/MetadataFormatter.java
+++ b/src/main/java/com/kttdevelopment/rexedia/format/MetadataFormatter.java
@@ -14,14 +14,18 @@ import java.util.logging.Logger;
 
 public final class MetadataFormatter {
 
+    private final int verify, verifyDiscrepancy;
     private final boolean preserveCover, preserveMetadata, preserveBackup;
     private final FFMPEG ffmpeg;
     private final Preset preset;
 
     public MetadataFormatter(final Configuration configuration, final FFMPEG ffmpeg, final Preset preset){
-        this.preserveCover    = (boolean) configuration.getConfiguration().get(Configuration.PRECOV);
-        this.preserveMetadata = (boolean) configuration.getConfiguration().get(Configuration.PREMETA);
-        this.preserveBackup   = (boolean) configuration.getConfiguration().get(Configuration.BACKUP);
+        final Map<String,?> config = configuration.getConfiguration();
+        this.verify             = (int) config.get(Configuration.VERIFY);
+        this.verifyDiscrepancy  = (int) config.get(Configuration.VERDIFF);
+        this.preserveCover      = (boolean) config.get(Configuration.PRECOV);
+        this.preserveMetadata   = (boolean) config.get(Configuration.PREMETA);
+        this.preserveBackup     = (boolean) config.get(Configuration.BACKUP);
 
         this.ffmpeg = ffmpeg;
         this.preset = preset;
@@ -37,7 +41,7 @@ public final class MetadataFormatter {
         {
             logger.info(String.format(lstr, "VERIFY / MEDIA ", 1));
             logger.fine("Verifying " + abs);
-            if(!ffmpeg.verifyFileIntegrity(file)){
+            if(!ffmpeg.verifyFileIntegrity(file, verify, verifyDiscrepancy)){
                 logger.severe("Failed to verify " + abs + " (file was " + (file.exists() ? "corrupt" : "missing") + ")");
                 return false;
             }else
@@ -72,7 +76,7 @@ public final class MetadataFormatter {
             // verify backup integrity
             logger.info(String.format(lstr, "VERIFY / BACKUP", 3));
             logger.fine("Verifying backup " + babs);
-            if(!ffmpeg.verifyFileIntegrity(backup)){
+            if(!ffmpeg.verifyFileIntegrity(backup, verify, verifyDiscrepancy)){
                 logger.severe("Failed to verify " + babs + " (file was " + (backup.exists() ? "corrupt" : "missing") + ")");
                 return false;
             }else
@@ -120,7 +124,7 @@ public final class MetadataFormatter {
         {
             logger.fine("Verifying output " + abs);
             logger.info(String.format(lstr, "VERIFY / FINAL ", 5));
-            if(!ffmpeg.verifyFileIntegrity(output)){
+            if(!ffmpeg.verifyFileIntegrity(output, verify, verifyDiscrepancy)){
                 logger.severe("Failed to verify output " + abs + " (file was corrupt)");
                 return false;
             }else

--- a/src/main/java/com/kttdevelopment/rexedia/logger/LoggerFormatter.java
+++ b/src/main/java/com/kttdevelopment/rexedia/logger/LoggerFormatter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.logger;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/preset/MetadataPreset.java
+++ b/src/main/java/com/kttdevelopment/rexedia/preset/MetadataPreset.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.preset;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/preset/Preset.java
+++ b/src/main/java/com/kttdevelopment/rexedia/preset/Preset.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.preset;
 
 import com.kttdevelopment.rexedia.utility.ToStringBuilder;

--- a/src/main/java/com/kttdevelopment/rexedia/preset/PresetParser.java
+++ b/src/main/java/com/kttdevelopment/rexedia/preset/PresetParser.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.preset;
 
 import com.esotericsoftware.yamlbeans.YamlReader;

--- a/src/main/java/com/kttdevelopment/rexedia/utility/CollectionsUtility.java
+++ b/src/main/java/com/kttdevelopment/rexedia/utility/CollectionsUtility.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.utility;
 
 import java.util.*;

--- a/src/main/java/com/kttdevelopment/rexedia/utility/ExceptionUtility.java
+++ b/src/main/java/com/kttdevelopment/rexedia/utility/ExceptionUtility.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.utility;
 
 import java.io.PrintWriter;

--- a/src/main/java/com/kttdevelopment/rexedia/utility/FileUtility.java
+++ b/src/main/java/com/kttdevelopment/rexedia/utility/FileUtility.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.utility;
 
 import java.io.File;

--- a/src/main/java/com/kttdevelopment/rexedia/utility/ToStringBuilder.java
+++ b/src/main/java/com/kttdevelopment/rexedia/utility/ToStringBuilder.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Ktt Development
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.kttdevelopment.rexedia.utility;
 
 import java.util.*;

--- a/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
+++ b/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
@@ -48,6 +48,7 @@ public class ffmpegTests {
     public void testVerify(){
         Assertions.assertTrue(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/video.mp4"), 3, 0));
         Assertions.assertFalse(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/corrupt.mp4"), 3, 0));
+        Assertions.assertFalse(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/apply/cover.png"), 3, 0));
     }
 
     private static final File input = new File("src/test/resources/format/apply/clean.mp4");

--- a/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
+++ b/src/test/java/com/kttdevelopment/rexedia/format/ffmpegTests.java
@@ -46,8 +46,8 @@ public class ffmpegTests {
 
     @Test
     public void testVerify(){
-        Assertions.assertTrue(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/video.mp4")));
-        Assertions.assertFalse(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/corrupt.mp4")));
+        Assertions.assertTrue(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/video.mp4"), 3, 0));
+        Assertions.assertFalse(ffmpeg.verifyFileIntegrity(new File("src/test/resources/format/corrupt.mp4"), 3, 0));
     }
 
     private static final File input = new File("src/test/resources/format/apply/clean.mp4");


### PR DESCRIPTION
Adds new flags:
- <kbd>-v</kbd> <kbd>-verify</kbd> levels
  > 0 = off (default)
  > 1 = similar frame count (see `-vs`)
  > 2 = frames equal to or exceeding (file frames exceed declared)
  > 3 = frames equal to
- <kbd>-vd</kbd> <kbd>-verifyDiscrepancy</kbd>
  > Default value is 100 frames, must be positive

Changes:

- Adds debug frame difference
- Closes #33 
- Closes #24 
- Bumps copyright to 2021